### PR TITLE
docs: clarify small-beta strong-coupling terminology (RH-1A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ At the present stage, the project does **not**:
 - prove exponential clustering in an infinite-volume setting, or with
   constants uniform when the observable supports themselves grow
   (stone 50 is a finite-volume clustering bound with a local,
-  ambient-volume-free prefactor, at small coupling only);
+  ambient-volume-free prefactor, in the small-β (strong-coupling) regime only);
 - prove the Yang–Mills mass gap.
 
 A formal statement of a lattice mass-gap target may appear in the library, but the

--- a/RELEASE_NOTES_PEDRA49.md
+++ b/RELEASE_NOTES_PEDRA49.md
@@ -6,7 +6,7 @@
 > **log Z_β = Σ'ₙ Bₙ(w_β)** for **0 ≤ β ≤ 1/40000**, with the signed unrooted
 > Ursell series absolutely convergent.
 
-This is a finite-volume lattice identity under small coupling. It is NOT a
+This is a finite-volume lattice identity in the small-β (strong-coupling) regime. It is NOT a
 thermodynamic-limit statement, NOT clustering/exponential decay, NOT a
 continuum result, NOT a mass-gap or Clay-problem claim.
 

--- a/RELEASE_NOTES_PEDRA50.md
+++ b/RELEASE_NOTES_PEDRA50.md
@@ -12,7 +12,7 @@
 
 Principal declaration: `LatticeGauge.abs_gibbsCovariance_le_local_exp_decay`.
 
-Explicitly: finite volume; small coupling (β ≤ 1/40000); exponential rate 1/2
+Explicitly: finite volume; small β (strong coupling), with β ≤ 1/40000; exponential rate 1/2
 in the separation parameter; no external nonvanishing hypothesis on `Z`
 anywhere in the chain — positivity and nonvanishing of the partition function
 and of the restricted gases are **outputs** of the cluster expansion.
@@ -24,7 +24,7 @@ the ambient finite lattice. This does not construct an infinite-volume Gibbs
 state, prove a thermodynamic limit, or provide a constant uniform when the
 observable supports themselves grow.
 
-This is a finite-volume lattice result under small coupling. It is NOT a
+This is a finite-volume lattice result in the small-β (strong-coupling) regime. It is NOT a
 thermodynamic-limit statement, NOT an infinite-volume result, NOT a
 continuum result, NOT a Yang–Mills mass-gap claim, and NOT a solution of the
 Clay Millennium Problem.


### PR DESCRIPTION
Documentation-only correction (audit RH-0, tape RH-1A). Replaces the ambiguous phrase "small coupling" by the explicit Wilson-convention wording "small-β (strong-coupling) regime" in four places:

- `README.md`: `at small coupling only` → `in the small-β (strong-coupling) regime only`
- `RELEASE_NOTES_PEDRA49.md`: `under small coupling` → `in the small-β (strong-coupling) regime`
- `RELEASE_NOTES_PEDRA50.md`: `small coupling (β ≤ 1/40000)` → `small β (strong coupling), with β ≤ 1/40000`
- `RELEASE_NOTES_PEDRA50.md`: `under small coupling` → `in the small-β (strong-coupling) regime`

3 files, +4/−4. No Lean source, lakefile, pin, workflow, tag, release or Zenodo record touched. Single commit `e0681bb8a354ffbbc91980137af6e6eb786e4435` on `807900449c70b2130fb18544a628c118b8f9fb1c`; to be merged with a merge commit.