### PR TITLE
docs: acknowledge Lean community feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,14 @@ the physical Yang–Mills problem.
 
 ---
 
+## Community feedback and acknowledgments
+
+We thank Michael R Douglas, Colin Bundschu, Jack McCarthy, and Ron Nissim for the comments, critical feedback, and references shared during the public discussion of Version 49 in the Lean community.
+
+The feedback contributed to the terminology correction and to the repository-reorganization roadmap adopted for Version 51 and subsequent work.
+
+These acknowledgments recognize public feedback and pointers to related work. They do not imply coauthorship, endorsement of the present results, or participation in the Lean proofs. The formal verification record is determined by the Lean 4 kernel and the project’s continuous-integration builds.
+
 ## Current roadmap
 
 The immediate Phase 3 roadmap is:


### PR DESCRIPTION
Adds the "Community feedback and acknowledgments" section to `README.md`, immediately before "## Current roadmap" (tape 51-ACK1-P).

- 1 commit: `7ec0523261cb24e1bcd179dd3a2428c01333ccde` on top of `main = 5a01fec4eb3e19517290d9f3ce4037ed9dff5285`
- 1 file: `README.md` (+8)
- No change to release notes, licenses, verification status, Phase1/, Phase2/, Phase3/, .github/, lakefiles, toolchain or pins.

To be integrated by merge commit only (no squash, no rebase). No tag, release or Zenodo action in this PR.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QN2cH6LhfducVPfZp4vSXA